### PR TITLE
Fixes a bug where if the initial value was null it threw an exception

### DIFF
--- a/src/datetimepicker.directive.ts
+++ b/src/datetimepicker.directive.ts
@@ -36,7 +36,7 @@ export class DateTimePickerDirective implements OnInit, OnChanges {
         this.dpElement.data('DateTimePicker').date(this.date);
 
         this.dpElement.on('dp.change', (e) => {
-            if (e.date.valueOf() !== this.date.valueOf()) {
+            if (e.date && e.date.valueOf() !== this.date.valueOf()) {
                 this.date = e.date;
                 this.onChange.emit(e.date);
             }


### PR DESCRIPTION
Basically it just wasn't checking to see if the date existed before trying to get its value.