### PR TITLE
Fix setting dirty upon control init

### DIFF
--- a/src/datetimepicker.directive.ts
+++ b/src/datetimepicker.directive.ts
@@ -76,10 +76,11 @@ export class DateTimePickerDirective implements OnInit, OnDestroy, DoCheck {
 
     writeValue(value) {
         if (!value) {
-            this.value = null;
+            this._value = null;
+        } else {
+            this._value = value;
         }
-        this.value = value;
-        this.setDpValue(value);
+        this.setDpValue(this._value);
     }
 
     registerOnChange(fn) {


### PR DESCRIPTION
Without the change the containing form (and the control) will be set to dirty right at the initialization, since writeValue is triggering the onChange event.

The expected behaviour is that only user interaction with the control should set dirty flag. Programatic change should not.